### PR TITLE
Ellipsis pls

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -9,8 +9,10 @@ const __dirname = path.dirname(__filename); // get the name of the directory
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   webpack(config) {
+    const fileLoaderRule = config.module.rules.find((rule) =>
+      rule.test?.test?.('.svg'),
+    )
     if (!fileLoaderRule) return config; // Early return if no SVG rule is found
-      rule.test?.test?.('.svg')
 
     config.module.rules.push(
       // Reapply the existing rule, but only for svg imports ending in ?url

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -10,8 +10,7 @@ const __dirname = path.dirname(__filename); // get the name of the directory
 const nextConfig = {
   webpack(config) {
     if (!fileLoaderRule) return config; // Early return if no SVG rule is found
-      rule.test?.test?.('.svg'),
-    )
+      rule.test?.test?.('.svg')
 
     config.module.rules.push(
       // Reapply the existing rule, but only for svg imports ending in ?url


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 88da6ea7dfd738e4e737e46887e545de0b3514c5  | 
|--------|--------|

### Summary:
Modified `next.config.mjs` to handle SVG imports differently in Webpack, treating `?url` SVGs as URLs and converting others to React components.

**Key points**:
- Modified `next.config.mjs` to update Webpack configuration.
- Added logic to handle SVG imports differently.
- SVG files ending with `?url` are treated as URLs.
- Other SVG imports are converted to React components using `@svgr/webpack`.
- Updated existing file loader rule to exclude SVG files.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->